### PR TITLE
Fix Item Amount Filtering

### DIFF
--- a/GatheringTracker.lua
+++ b/GatheringTracker.lua
@@ -574,7 +574,7 @@ function GT:SetupItemRows()
                 count = GT.InventoryData[itemID].count
             end
 
-            if count > 0 or GT.db.profile.General.allFiltered then
+            if (count > 0 and count > GT.db.profile.General.ignoreAmount) or GT.db.profile.General.allFiltered then
                 local pricePerItem = nil
                 local itemsPerHour = nil
                 local goldPerHour = nil


### PR DESCRIPTION
This pull request updates the logic in the `GT:SetupItemRows()` function to improve how items are filtered based on their count and the user-configured `ignoreAmount` setting. Now, an item will only be included if its count is greater than both zero and the `ignoreAmount`, unless the `allFiltered` setting is enabled.

- Improved item filtering logic in `GT:SetupItemRows()` to only include items whose count exceeds the `ignoreAmount` threshold, unless `allFiltered` is enabled.

Fixes #44 